### PR TITLE
Fix log configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 IP  = ENV.fetch('IP', '192.168.33.200')
-BOX = ENV.fetch('BOX', 'debian-7')
+BOX = ENV.fetch('BOX', 'chef/debian-7.6')
 
 Vagrant.configure("2") do |config|
   config.vm.box      = BOX

--- a/site-cookbooks/polipo/templates/default/config.erb
+++ b/site-cookbooks/polipo/templates/default/config.erb
@@ -153,3 +153,6 @@ allowedClients = <%= node['polipo']['allowed_clients'] %>
 # Vary header (this is not a good idea):
 
 # mindlesslyCacheVary = true
+
+logSyslog = true
+logFile = /var/log/polipo/polipo.log


### PR DESCRIPTION
Polipo installed on Ubuntu, after being restarted with the Chef generated configuration, will try to use `/var/log/polipo` as its log file.
It fails because the log directory `/var/log/polipo` was created during the first execution (before Chef conf generation).
This issue did not appear on Debian.

This fix keeps the Debian install working

Also, added a default box that will allow a `vagrant up` with no configuration
